### PR TITLE
Updating gitlab-shell version to 2.6.12

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -100,7 +100,7 @@ gitlab_version_map:
     gitlab_workhorse: '0.6.4'
 
   '8.6':
-    shell: 'v2.6.11'
+    shell: 'v2.6.12'
     ce:    '8-6-stable'
     gitlab_workhorse: 'v0.7.1'
 


### PR DESCRIPTION
Hello
After updating gitlab to 8.6 , the backup cron failed to run as the version of gitlab-shell is incorrect :

```
WARNING: This version of GitLab depends on gitlab-shell 2.6.12, but you're running 2.6.11. Please update gitlab-shell.
```

I've changed the version and the update went well.
